### PR TITLE
deploy vetiver to rsconnect

### DIFF
--- a/model/01-train-and-deploy-model/vetiver_deployment.ipynb
+++ b/model/01-train-and-deploy-model/vetiver_deployment.ipynb
@@ -11,27 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "03c08433-f6d3-480e-81ad-90899371b147",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from vetiver.server import predict, vetiver_endpoint"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
    "id": "cfe8a016-89ec-4b7f-903f-a8ac6307ee2d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pins"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "9c27d557-2073-4b9a-882b-7116f37d81ae",
    "metadata": {},
    "outputs": [
     {
@@ -40,65 +20,47 @@
        "True"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "import vetiver as vt\n",
+    "import pins\n",
+    "\n",
+    "from rsconnect.api import RSConnectServer\n",
+    "import os\n",
     "from dotenv import load_dotenv\n",
     "load_dotenv(override=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "644b7b90-862e-4a31-97aa-393e9c09ea0e",
+   "execution_count": 2,
+   "id": "9c27d557-2073-4b9a-882b-7116f37d81ae",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os"
+    "rsc_server=os.getenv(\"CONNECT_SERVER\")\n",
+    "rsc_key=os.getenv(\"CONNECT_API_KEY\")\n",
+    "connect_server = RSConnectServer(url=rsc_server, api_key=rsc_key)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "3829d186-8158-47d5-ae40-537ac66611d9",
    "metadata": {},
    "outputs": [],
    "source": [
     "board = pins.board_rsconnect(server_url=\"https://colorado.rstudio.com/rsc\",\n",
-    "                            allow_pickle_read=True)"
+    "                            allow_pickle_read=True, api_key=rsc_key)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "7ee9ac79-5595-45cf-9284-5779f114a7ba",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "RandomForestRegressor(max_depth=20, max_features='sqrt', min_samples_leaf=0.5,\n",
-       "                      min_samples_split=0.5, n_jobs=6, random_state=0,\n",
-       "                      verbose=100)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# read the pinned model\n",
-    "model = board.pin_read(\"gagan/bikeshare-rf-2306\")\n",
-    "model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "ca0f5223-4aeb-4cfb-ad4b-8d3b8624fb93",
    "metadata": {
     "collapsed": true,
@@ -332,7 +294,7 @@
        "[213723 rows x 11 columns]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -344,15 +306,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "f1b03bec-c002-461d-8e33-bf84b1921259",
+   "execution_count": 5,
+   "id": "435cb719-5999-4d8c-bdd2-d8b4b24a8f23",
    "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    },
     "tags": []
    },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Scikit-learn <class 'sklearn.ensemble._forest.RandomForestRegressor'> model\""
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# here you can choose to load this model and make the\n",
+    "# API to debug/click around locally if you want--\n",
+    "# but you don't actually need to create a VetiverAPI(), \n",
+    "# you can deploy right from your pinned VetiverModel()\n",
+    "\n",
+    "v = vt.VetiverModel.from_pin(board, \"isabel.zimmerman/iz-bike\", version = \"58519\")\n",
+    "v.description"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "af32da6a-9986-4853-9f91-3213d5e3163d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app = vt.VetiverAPI(v)\n",
+    "# app.run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cbf5c9df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the first time i did this, it took about 10 mins\n",
+    "# the second time, it took about 15 seconds\n",
+    "vt.deploy_rsconnect(\n",
+    "    connect_server=connect_server,\n",
+    "    board=board,\n",
+    "    pin_name=\"isabel.zimmerman/iz-bike\",\n",
+    "    version=\"58519\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fe3479fb",
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -375,659 +388,103 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>hour</th>\n",
-       "      <th>month</th>\n",
-       "      <th>lat</th>\n",
-       "      <th>lon</th>\n",
-       "      <th>Friday</th>\n",
-       "      <th>Monday</th>\n",
-       "      <th>Saturday</th>\n",
-       "      <th>Sunday</th>\n",
-       "      <th>Thursday</th>\n",
-       "      <th>Tuesday</th>\n",
-       "      <th>Wednesday</th>\n",
+       "      <th>prediction</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>4</td>\n",
-       "      <td>10</td>\n",
-       "      <td>38.933668</td>\n",
-       "      <td>-76.991016</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>4</td>\n",
-       "      <td>10</td>\n",
-       "      <td>38.933668</td>\n",
-       "      <td>-76.991016</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>4</td>\n",
-       "      <td>10</td>\n",
-       "      <td>38.933668</td>\n",
-       "      <td>-76.991016</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>4</td>\n",
-       "      <td>10</td>\n",
-       "      <td>38.933668</td>\n",
-       "      <td>-76.991016</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>4</td>\n",
-       "      <td>10</td>\n",
-       "      <td>38.933668</td>\n",
-       "      <td>-76.991016</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
        "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2035446</th>\n",
-       "      <td>5</td>\n",
-       "      <td>8</td>\n",
-       "      <td>38.882788</td>\n",
-       "      <td>-77.103148</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <th>213718</th>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2035447</th>\n",
-       "      <td>5</td>\n",
-       "      <td>8</td>\n",
-       "      <td>38.882788</td>\n",
-       "      <td>-77.103148</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <th>213719</th>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2035448</th>\n",
-       "      <td>5</td>\n",
-       "      <td>8</td>\n",
-       "      <td>38.882788</td>\n",
-       "      <td>-77.103148</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <th>213720</th>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2035449</th>\n",
-       "      <td>5</td>\n",
-       "      <td>8</td>\n",
-       "      <td>38.882788</td>\n",
-       "      <td>-77.103148</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
+       "      <th>213721</th>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2035450</th>\n",
-       "      <td>5</td>\n",
-       "      <td>8</td>\n",
-       "      <td>38.882788</td>\n",
-       "      <td>-77.103148</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>0</td>\n",
+       "      <th>213722</th>\n",
+       "      <td>9.000276</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>2000000 rows × 11 columns</p>\n",
+       "<p>213723 rows × 1 columns</p>\n",
        "</div>"
       ],
       "text/plain": [
-       "         hour  month        lat        lon  Friday  Monday  Saturday  Sunday  \\\n",
-       "0           4     10  38.933668 -76.991016       0       0         0       1   \n",
-       "1           4     10  38.933668 -76.991016       0       1         0       0   \n",
-       "2           4     10  38.933668 -76.991016       0       0         0       0   \n",
-       "3           4     10  38.933668 -76.991016       0       0         0       0   \n",
-       "4           4     10  38.933668 -76.991016       0       0         0       0   \n",
-       "...       ...    ...        ...        ...     ...     ...       ...     ...   \n",
-       "2035446     5      8  38.882788 -77.103148       1       0         0       0   \n",
-       "2035447     5      8  38.882788 -77.103148       0       0         1       0   \n",
-       "2035448     5      8  38.882788 -77.103148       0       0         0       1   \n",
-       "2035449     5      8  38.882788 -77.103148       0       1         0       0   \n",
-       "2035450     5      8  38.882788 -77.103148       0       0         0       0   \n",
+       "        prediction\n",
+       "0         9.000276\n",
+       "1         9.000276\n",
+       "2         9.000276\n",
+       "3         9.000276\n",
+       "4         9.000276\n",
+       "...            ...\n",
+       "213718    9.000276\n",
+       "213719    9.000276\n",
+       "213720    9.000276\n",
+       "213721    9.000276\n",
+       "213722    9.000276\n",
        "\n",
-       "         Thursday  Tuesday  Wednesday  \n",
-       "0               0        0          0  \n",
-       "1               0        0          0  \n",
-       "2               0        1          0  \n",
-       "3               0        0          1  \n",
-       "4               1        0          0  \n",
-       "...           ...      ...        ...  \n",
-       "2035446         0        0          0  \n",
-       "2035447         0        0          0  \n",
-       "2035448         0        0          0  \n",
-       "2035449         0        0          0  \n",
-       "2035450         0        1          0  \n",
-       "\n",
-       "[2000000 rows x 11 columns]"
+       "[213723 rows x 1 columns]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "X_train = board.pin_read(\"gagan/bike_x_train\")\n",
-    "X_train"
+    "# this chunk takes about 45 seconds, to make 213,723 predictions\n",
+    "endpoint = vt.vetiver_endpoint(url=\"https://colorado.rstudio.com/rsc/content/d7719db4-83e1-49b4-a924-a3348e6d98d4/predict/\")\n",
+    "\n",
+    "h = { 'Authorization': f'Key {rsc_key}' } # only needed if not open to public\n",
+    "vt.predict(endpoint = endpoint, data = X_test, headers=h)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "8751f08d-4738-46ee-814f-266f12a12652",
+   "execution_count": null,
+   "id": "29e416d6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from vetiver import VetiverModel, VetiverAPI, vetiver_endpoint,vetiver_write_app,pin_read_write"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "435cb719-5999-4d8c-bdd2-d8b4b24a8f23",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "v = VetiverModel(model, \"gagan/bikeshare-rf-2306\", save_ptype = True, ptype_data=X_train)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "id": "af32da6a-9986-4853-9f91-3213d5e3163d",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<vetiver.vetiver_model.VetiverModel at 0x7fc7d63d2ee0>"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "v"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "b67bbcb8-7cdb-4f78-b230-46e12a0e7652",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<vetiver.server.VetiverAPI at 0x7fc7d63d28e0>"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "app = VetiverAPI(v, check_ptype=True)\n",
-    "app"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "1added44-3d7d-438d-bf2a-64d3d6d73f30",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Writing pin:\n",
-      "Name: 'gagan/bikeshare-rf-2306'\n",
-      "Version: 20220623T172924Z-282d5\n"
-     ]
-    }
-   ],
-   "source": [
-    "pin_read_write.vetiver_pin_write(\n",
-    "board,\n",
-    "v\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "5547173b-b436-40c3-a6dd-36821132da88",
-   "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/home/gagan/bike_predict_vetiver/.bike_predict_vetiver/lib/python3.9/site-packages/vetiver/write_fastapi.py:20: UserWarning: Pinned vetiver model has no active version and no datetime on versions,\n",
-      "              Do you need to check your pinned model?\n",
-      "              Using version 58019\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
-   "source": [
-    "# create fastAPI endpoint\n",
-    "# (will be replaced by Connect deplpoyment function)\n",
-    "vetiver_write_app(\n",
-    "board,\n",
-    "\"gagan/bikeshare-rf-2306\",\n",
-    "file=\"model_new.py\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "484c3c2b-45e7-4bc6-a8f5-70bdf1881c3d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from rsconnect.api import RSConnectServer\n",
-    "from rsconnect.actions import deploy_python_fastapi"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "c645cf9a-34af-4f1a-a282-3f15fa7a1819",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rsc_server=os.getenv(\"CONNECT_SERVER\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "e060a89e-ed44-41ec-94a2-5f547c720e11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rsc_key=os.getenv(\"CONNECT_API_KEY\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "9db07360-88ee-41fc-b10d-6d5a3466055e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "connect_server = RSConnectServer(url=rsc_server, api_key=rsc_key)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "id": "a0bebb6d-acd5-48ce-a372-9607b4c5d6fe",
-   "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('https://colorado.rstudio.com/rsc/connect/#/apps/c6adc932-88f0-4536-a5c1-f6c1f6086244',\n",
-       " ['Building FastAPI application...',\n",
-       "  'Bundle created with Python version 3.9.6 is compatible with environment Kubernetes::ghcr.io/rstudio/content-pro:r4.0.5-py3.9.2-bionic with Python version 3.9.2 from /opt/python/3.9.2/bin/python3.9 ',\n",
-       "  'Bundle requested Python version 3.9.6; using /opt/python/3.9.2/bin/python3.9 from Kubernetes::ghcr.io/rstudio/content-pro:r4.0.5-py3.9.2-bionic which has version 3.9.2',\n",
-       "  'Determining session server location ...',\n",
-       "  'Connecting to session server http://172.19.57.196:32636 ...',\n",
-       "  '2022/06/23 17:41:42.477249279 Running on host: python-environment-restore-spz57-tgdwh',\n",
-       "  '2022/06/23 17:41:42.477266021 Working directory: /opt/rstudio-connect/mnt/app',\n",
-       "  '2022/06/23 17:41:42.477342326 Environment will be built with Python \"3.9.2 (default, Mar  3 2021, 20:02:32)  [GCC 7.3.0]\" at /opt/python/3.9.2/bin/python3.9',\n",
-       "  '2022/06/23 17:41:42.477742162 Running as user: 999',\n",
-       "  '2022/06/23 17:41:42.520626082 Skipped packages: setuptools==56.0.0',\n",
-       "  '2022/06/23 17:41:42.520639793 Creating environment: 0ayN2gFf0XzZbelHEANT0A',\n",
-       "  'Connected to session server http://172.19.57.196:32636',\n",
-       "  '2022/06/23 17:41:59.625960856 Collecting pip',\n",
-       "  '2022/06/23 17:41:59.695626483   Downloading pip-22.1.2-py3-none-any.whl (2.1 MB)',\n",
-       "  '2022/06/23 17:42:01.283419165 Collecting setuptools',\n",
-       "  '2022/06/23 17:42:01.323078125   Downloading setuptools-62.6.0-py3-none-any.whl (1.2 MB)',\n",
-       "  '2022/06/23 17:42:01.529010777 Requirement already up-to-date: wheel in /opt/python/3.9.2/lib/python3.9/site-packages (0.37.1)',\n",
-       "  '2022/06/23 17:42:01.739988765 Installing collected packages: pip, setuptools',\n",
-       "  '2022/06/23 17:42:01.740292345   Attempting uninstall: pip',\n",
-       "  '2022/06/23 17:42:01.740533529     Found existing installation: pip 20.2.3',\n",
-       "  '2022/06/23 17:42:03.224126548     Uninstalling pip-20.2.3:',\n",
-       "  '2022/06/23 17:42:03.451523364       Successfully uninstalled pip-20.2.3',\n",
-       "  '2022/06/23 17:42:19.227630657   Attempting uninstall: setuptools',\n",
-       "  '2022/06/23 17:42:19.228186794     Found existing installation: setuptools 49.2.1',\n",
-       "  '2022/06/23 17:42:19.839562827     Uninstalling setuptools-49.2.1:',\n",
-       "  '2022/06/23 17:42:20.282796157       Successfully uninstalled setuptools-49.2.1',\n",
-       "  '2022/06/23 17:42:26.857451737 Successfully installed pip-22.1.2 setuptools-62.6.0',\n",
-       "  '2022/06/23 17:42:30.190145688 Collecting anyio==3.5.0',\n",
-       "  '2022/06/23 17:42:30.251092496   Using cached anyio-3.5.0-py3-none-any.whl (79 kB)',\n",
-       "  '2022/06/23 17:42:30.262178215 Requirement already satisfied: appdirs==1.4.4 in /opt/python/3.9.2/lib/python3.9/site-packages (from -r python/requirements.txt (line 2)) (1.4.4)',\n",
-       "  '2022/06/23 17:42:30.401728739 Collecting argon2-cffi==21.3.0',\n",
-       "  '2022/06/23 17:42:30.472112377   Using cached argon2_cffi-21.3.0-py3-none-any.whl (14 kB)',\n",
-       "  '2022/06/23 17:42:30.590866862 Collecting argon2-cffi-bindings==21.2.0',\n",
-       "  '2022/06/23 17:42:30.639723173   Using cached argon2_cffi_bindings-21.2.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (86 kB)',\n",
-       "  '2022/06/23 17:42:30.785033899 Collecting asgiref==3.5.1',\n",
-       "  '2022/06/23 17:42:30.830733887   Using cached asgiref-3.5.1-py3-none-any.whl (22 kB)',\n",
-       "  '2022/06/23 17:42:30.947205064 Collecting asttokens==2.0.5',\n",
-       "  '2022/06/23 17:42:31.011610218   Using cached asttokens-2.0.5-py2.py3-none-any.whl (20 kB)',\n",
-       "  '2022/06/23 17:42:31.105646367 Collecting attrs==21.4.0',\n",
-       "  '2022/06/23 17:42:31.147305421   Using cached attrs-21.4.0-py2.py3-none-any.whl (60 kB)',\n",
-       "  '2022/06/23 17:42:31.216789703 Collecting backcall==0.2.0',\n",
-       "  '2022/06/23 17:42:31.255074789   Using cached backcall-0.2.0-py2.py3-none-any.whl (11 kB)',\n",
-       "  '2022/06/23 17:42:31.341043335 Collecting beautifulsoup4==4.11.1',\n",
-       "  '2022/06/23 17:42:31.380991441   Using cached beautifulsoup4-4.11.1-py3-none-any.whl (128 kB)',\n",
-       "  '2022/06/23 17:42:31.487400276 Collecting bleach==5.0.0',\n",
-       "  '2022/06/23 17:42:31.525032706   Using cached bleach-5.0.0-py3-none-any.whl (160 kB)',\n",
-       "  '2022/06/23 17:42:31.614590577 Collecting certifi==2021.10.8',\n",
-       "  '2022/06/23 17:42:31.666736180   Using cached certifi-2021.10.8-py2.py3-none-any.whl (149 kB)',\n",
-       "  '2022/06/23 17:42:32.001148804 Collecting cffi==1.15.0',\n",
-       "  '2022/06/23 17:42:32.046167071   Using cached cffi-1.15.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (444 kB)',\n",
-       "  '2022/06/23 17:42:32.142313071 Collecting charset-normalizer==2.0.12',\n",
-       "  '2022/06/23 17:42:32.181502788   Using cached charset_normalizer-2.0.12-py3-none-any.whl (39 kB)',\n",
-       "  '2022/06/23 17:42:32.271295767 Collecting click==8.1.3',\n",
-       "  '2022/06/23 17:42:32.310859990   Using cached click-8.1.3-py3-none-any.whl (96 kB)',\n",
-       "  '2022/06/23 17:42:32.608357228 Collecting debugpy==1.6.0',\n",
-       "  '2022/06/23 17:42:32.655749558   Using cached debugpy-1.6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (1.8 MB)',\n",
-       "  '2022/06/23 17:42:32.760708493 Collecting decorator==5.1.1',\n",
-       "  '2022/06/23 17:42:32.795320596   Using cached decorator-5.1.1-py3-none-any.whl (9.1 kB)',\n",
-       "  '2022/06/23 17:42:32.869101408 Collecting defusedxml==0.7.1',\n",
-       "  '2022/06/23 17:42:32.906329956   Using cached defusedxml-0.7.1-py2.py3-none-any.whl (25 kB)',\n",
-       "  '2022/06/23 17:42:32.987736868 Collecting entrypoints==0.4',\n",
-       "  '2022/06/23 17:42:33.034769899   Using cached entrypoints-0.4-py3-none-any.whl (5.3 kB)',\n",
-       "  '2022/06/23 17:42:33.106427834 Collecting executing==0.8.3',\n",
-       "  '2022/06/23 17:42:33.143694516   Using cached executing-0.8.3-py2.py3-none-any.whl (16 kB)',\n",
-       "  '2022/06/23 17:42:33.300640152 Collecting fastapi==0.75.2',\n",
-       "  '2022/06/23 17:42:33.339834474   Using cached fastapi-0.75.2-py3-none-any.whl (54 kB)',\n",
-       "  '2022/06/23 17:42:33.412678485 Collecting fastjsonschema==2.15.3',\n",
-       "  '2022/06/23 17:42:33.467325836   Using cached fastjsonschema-2.15.3-py3-none-any.whl (22 kB)',\n",
-       "  '2022/06/23 17:42:33.597993999 Collecting fsspec==2022.3.0',\n",
-       "  '2022/06/23 17:42:33.676918605   Using cached fsspec-2022.3.0-py3-none-any.whl (136 kB)',\n",
-       "  '2022/06/23 17:42:33.889785881 Collecting greenlet==1.1.2',\n",
-       "  '2022/06/23 17:42:33.928744877   Using cached greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (153 kB)',\n",
-       "  '2022/06/23 17:42:33.996343449 Collecting h11==0.13.0',\n",
-       "  '2022/06/23 17:42:34.035171077   Using cached h11-0.13.0-py3-none-any.whl (58 kB)',\n",
-       "  '2022/06/23 17:42:34.129056061 Collecting humanize==4.1.0',\n",
-       "  '2022/06/23 17:42:34.169521099   Using cached humanize-4.1.0-py3-none-any.whl (101 kB)',\n",
-       "  '2022/06/23 17:42:34.245214474 Collecting idna==3.3',\n",
-       "  '2022/06/23 17:42:34.282773900   Using cached idna-3.3-py3-none-any.whl (61 kB)',\n",
-       "  '2022/06/23 17:42:34.437392539 Collecting importlib-metadata==4.11.3',\n",
-       "  '2022/06/23 17:42:34.475892106   Using cached importlib_metadata-4.11.3-py3-none-any.whl (18 kB)',\n",
-       "  '2022/06/23 17:42:34.594911468 Collecting importlib-resources==5.7.1',\n",
-       "  '2022/06/23 17:42:34.636359309   Using cached importlib_resources-5.7.1-py3-none-any.whl (28 kB)',\n",
-       "  '2022/06/23 17:42:34.758191717 Collecting ipykernel==6.13.0',\n",
-       "  '2022/06/23 17:42:34.798595575   Using cached ipykernel-6.13.0-py3-none-any.whl (131 kB)',\n",
-       "  '2022/06/23 17:42:34.947934964 Collecting ipython==8.2.0',\n",
-       "  '2022/06/23 17:42:34.992833492   Using cached ipython-8.2.0-py3-none-any.whl (750 kB)',\n",
-       "  '2022/06/23 17:42:35.073313056 Collecting ipython-genutils==0.2.0',\n",
-       "  '2022/06/23 17:42:35.133002084   Using cached ipython_genutils-0.2.0-py2.py3-none-any.whl (26 kB)',\n",
-       "  '2022/06/23 17:42:35.219715946 Collecting jedi==0.18.1',\n",
-       "  '2022/06/23 17:42:35.264679773   Using cached jedi-0.18.1-py2.py3-none-any.whl (1.6 MB)',\n",
-       "  '2022/06/23 17:42:35.381146403 Collecting Jinja2==3.1.2',\n",
-       "  '2022/06/23 17:42:35.418670743   Using cached Jinja2-3.1.2-py3-none-any.whl (133 kB)',\n",
-       "  '2022/06/23 17:42:35.535428220 Collecting joblib==1.1.0',\n",
-       "  '2022/06/23 17:42:35.573377487   Using cached joblib-1.1.0-py2.py3-none-any.whl (306 kB)',\n",
-       "  '2022/06/23 17:42:35.670831995 Collecting jsonschema==4.5.1',\n",
-       "  '2022/06/23 17:42:35.711518427   Using cached jsonschema-4.5.1-py3-none-any.whl (72 kB)',\n",
-       "  '2022/06/23 17:42:35.816441151 Collecting jupyter-client==7.2.2',\n",
-       "  '2022/06/23 17:42:35.856690817   Using cached jupyter_client-7.2.2-py3-none-any.whl (130 kB)',\n",
-       "  '2022/06/23 17:42:35.961221103 Collecting jupyter-core==4.10.0',\n",
-       "  '2022/06/23 17:42:36.075593400   Using cached jupyter_core-4.10.0-py3-none-any.whl (87 kB)',\n",
-       "  '2022/06/23 17:42:36.193973672 Collecting jupyterlab-pygments==0.2.2',\n",
-       "  '2022/06/23 17:42:36.228488936   Using cached jupyterlab_pygments-0.2.2-py2.py3-none-any.whl (21 kB)',\n",
-       "  '2022/06/23 17:42:36.370528155 Collecting MarkupSafe==2.1.1',\n",
-       "  '2022/06/23 17:42:36.409932919   Using cached MarkupSafe-2.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (25 kB)',\n",
-       "  '2022/06/23 17:42:36.478197233 Collecting matplotlib-inline==0.1.3',\n",
-       "  '2022/06/23 17:42:36.513632893   Using cached matplotlib_inline-0.1.3-py3-none-any.whl (8.2 kB)',\n",
-       "  '2022/06/23 17:42:36.597382127 Collecting mistune==0.8.4',\n",
-       "  '2022/06/23 17:42:36.631021306   Using cached mistune-0.8.4-py2.py3-none-any.whl (16 kB)',\n",
-       "  '2022/06/23 17:42:36.716952007 Collecting nbclient==0.6.3',\n",
-       "  '2022/06/23 17:42:36.756146832   Using cached nbclient-0.6.3-py3-none-any.whl (71 kB)',\n",
-       "  '2022/06/23 17:42:36.853533856 Collecting nbconvert==6.5.0',\n",
-       "  '2022/06/23 17:42:36.894962588   Using cached nbconvert-6.5.0-py3-none-any.whl (561 kB)',\n",
-       "  '2022/06/23 17:42:36.989294988 Collecting nbformat==5.4.0',\n",
-       "  '2022/06/23 17:42:37.028697949   Using cached nbformat-5.4.0-py3-none-any.whl (73 kB)',\n",
-       "  '2022/06/23 17:42:37.114220073 Collecting nest-asyncio==1.5.5',\n",
-       "  '2022/06/23 17:42:37.150209741   Using cached nest_asyncio-1.5.5-py3-none-any.whl (5.2 kB)',\n",
-       "  '2022/06/23 17:42:37.261235027 Collecting notebook==6.4.11',\n",
-       "  '2022/06/23 17:42:37.339220084   Using cached notebook-6.4.11-py3-none-any.whl (9.9 MB)',\n",
-       "  '2022/06/23 17:42:37.929108085 Collecting numpy==1.22.3',\n",
-       "  '2022/06/23 17:42:38.041615525   Using cached numpy-1.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.8 MB)',\n",
-       "  '2022/06/23 17:42:38.242869244 Collecting packaging==21.3',\n",
-       "  '2022/06/23 17:42:38.282575185   Using cached packaging-21.3-py3-none-any.whl (40 kB)',\n",
-       "  '2022/06/23 17:42:38.618550297 Collecting pandas==1.4.2',\n",
-       "  '2022/06/23 17:42:38.703442764   Using cached pandas-1.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (11.7 MB)',\n",
-       "  '2022/06/23 17:42:38.900659842 Collecting pandocfilters==1.5.0',\n",
-       "  '2022/06/23 17:42:38.939374983   Using cached pandocfilters-1.5.0-py2.py3-none-any.whl (8.7 kB)',\n",
-       "  '2022/06/23 17:42:39.033373509 Collecting parso==0.8.3',\n",
-       "  '2022/06/23 17:42:39.071727743   Using cached parso-0.8.3-py2.py3-none-any.whl (100 kB)',\n",
-       "  '2022/06/23 17:42:39.161227745 Collecting pexpect==4.8.0',\n",
-       "  '2022/06/23 17:42:39.213636167   Using cached pexpect-4.8.0-py2.py3-none-any.whl (59 kB)',\n",
-       "  '2022/06/23 17:42:39.286275204 Collecting pickleshare==0.7.5',\n",
-       "  '2022/06/23 17:42:39.320592390   Using cached pickleshare-0.7.5-py2.py3-none-any.whl (6.9 kB)',\n",
-       "  '2022/06/23 17:42:39.396703548 Collecting pins==0.4.0',\n",
-       "  '2022/06/23 17:42:39.434992290   Using cached pins-0.4.0-py2.py3-none-any.whl (105 kB)',\n",
-       "  '2022/06/23 17:42:39.439489787 Requirement already satisfied: pip==22.1.2 in /opt/rstudio-connect/mnt/python-environments/ghcr.io_rstudio_content-pro__r4.0.5-py3.9.2-bionic/pip/3.9.2/0ayN2gFf0XzZbelHEANT0A/lib/python3.9/site-packages (from -r python/requirements.txt (line 55)) (22.1.2)',\n",
-       "  '2022/06/23 17:42:39.516913908 Collecting prometheus-client==0.14.1',\n",
-       "  '2022/06/23 17:42:39.554158556   Using cached prometheus_client-0.14.1-py3-none-any.whl (59 kB)',\n",
-       "  '2022/06/23 17:42:39.691585351 Collecting prompt-toolkit==3.0.29',\n",
-       "  '2022/06/23 17:42:39.732855620   Using cached prompt_toolkit-3.0.29-py3-none-any.whl (381 kB)',\n",
-       "  '2022/06/23 17:42:39.995376354 Collecting psutil==5.9.0',\n",
-       "  '2022/06/23 17:42:40.032972627   Using cached psutil-5.9.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (280 kB)',\n",
-       "  '2022/06/23 17:42:40.272733163 Collecting psycopg2==2.9.3',\n",
-       "  '2022/06/23 17:42:40.273027047   Using cached psycopg2-2.9.3-cp39-cp39-linux_x86_64.whl',\n",
-       "  '2022/06/23 17:42:40.381811494 Collecting ptyprocess==0.7.0',\n",
-       "  '2022/06/23 17:42:40.421026012   Using cached ptyprocess-0.7.0-py2.py3-none-any.whl (13 kB)',\n",
-       "  '2022/06/23 17:42:40.507307225 Collecting pure-eval==0.2.2',\n",
-       "  '2022/06/23 17:42:40.544852440   Using cached pure_eval-0.2.2-py3-none-any.whl (11 kB)',\n",
-       "  '2022/06/23 17:42:40.636933407 Collecting pycparser==2.21',\n",
-       "  '2022/06/23 17:42:40.682223197   Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)',\n",
-       "  '2022/06/23 17:42:40.916840520 Collecting pydantic==1.9.0',\n",
-       "  '2022/06/23 17:42:41.027336195   Using cached pydantic-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.2 MB)',\n",
-       "  '2022/06/23 17:42:41.210673257 Collecting Pygments==2.11.2',\n",
-       "  '2022/06/23 17:42:41.260133653   Using cached Pygments-2.11.2-py3-none-any.whl (1.1 MB)',\n",
-       "  '2022/06/23 17:42:41.489579237 Collecting pyodbc==4.0.32',\n",
-       "  '2022/06/23 17:42:41.489885984   Using cached pyodbc-4.0.32-cp39-cp39-linux_x86_64.whl',\n",
-       "  '2022/06/23 17:42:41.653182395 Collecting pyparsing==3.0.8',\n",
-       "  '2022/06/23 17:42:41.689591525   Using cached pyparsing-3.0.8-py3-none-any.whl (98 kB)',\n",
-       "  '2022/06/23 17:42:41.784328675 Collecting pyrsistent==0.18.1',\n",
-       "  '2022/06/23 17:42:41.822119344   Using cached pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (115 kB)',\n",
-       "  '2022/06/23 17:42:41.909158870 Collecting python-dateutil==2.8.2',\n",
-       "  '2022/06/23 17:42:41.945661166   Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)',\n",
-       "  '2022/06/23 17:42:42.068691537 Collecting python-dotenv==0.20.0',\n",
-       "  '2022/06/23 17:42:42.107188557   Using cached python_dotenv-0.20.0-py3-none-any.whl (17 kB)',\n",
-       "  '2022/06/23 17:42:42.265762365 Collecting pytz==2022.1',\n",
-       "  '2022/06/23 17:42:42.302196607   Using cached pytz-2022.1-py2.py3-none-any.whl (503 kB)',\n",
-       "  '2022/06/23 17:42:42.452019738 Collecting PyYAML==6.0',\n",
-       "  '2022/06/23 17:42:42.493900567   Using cached PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (661 kB)',\n",
-       "  '2022/06/23 17:42:42.899328770 Collecting pyzmq==22.3.0',\n",
-       "  '2022/06/23 17:42:42.943390248   Using cached pyzmq-22.3.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (1.1 MB)',\n",
-       "  '2022/06/23 17:42:43.087360628 Collecting requests==2.27.1',\n",
-       "  '2022/06/23 17:42:43.122059081   Using cached requests-2.27.1-py2.py3-none-any.whl (63 kB)',\n",
-       "  '2022/06/23 17:42:43.410267762 Collecting scikit-learn==1.0.2',\n",
-       "  '2022/06/23 17:42:43.570428343   Using cached scikit_learn-1.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (26.4 MB)',\n",
-       "  '2022/06/23 17:42:44.075135932 Collecting scipy==1.8.0',\n",
-       "  '2022/06/23 17:42:44.354477545   Using cached scipy-1.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (42.1 MB)',\n",
-       "  '2022/06/23 17:42:44.671429699 Collecting semver==2.13.0',\n",
-       "  '2022/06/23 17:42:44.721759391   Using cached semver-2.13.0-py2.py3-none-any.whl (12 kB)',\n",
-       "  '2022/06/23 17:42:44.800475908 Collecting Send2Trash==1.8.0',\n",
-       "  '2022/06/23 17:42:44.833920975   Using cached Send2Trash-1.8.0-py3-none-any.whl (18 kB)',\n",
-       "  '2022/06/23 17:42:44.838458421 Requirement already satisfied: six==1.16.0 in /opt/python/3.9.2/lib/python3.9/site-packages (from -r python/requirements.txt (line 78)) (1.16.0)',\n",
-       "  '2022/06/23 17:42:44.906552893 Collecting sklearn==0.0',\n",
-       "  '2022/06/23 17:42:44.906904554   Using cached sklearn-0.0-py2.py3-none-any.whl',\n",
-       "  '2022/06/23 17:42:44.971815169 Collecting sniffio==1.2.0',\n",
-       "  '2022/06/23 17:42:45.008436463   Using cached sniffio-1.2.0-py3-none-any.whl (10 kB)',\n",
-       "  '2022/06/23 17:42:45.100104047 Collecting soupsieve==2.3.2.post1',\n",
-       "  '2022/06/23 17:42:45.134323625   Using cached soupsieve-2.3.2.post1-py3-none-any.whl (37 kB)',\n",
-       "  '2022/06/23 17:42:45.647565047 Collecting SQLAlchemy==1.4.36',\n",
-       "  '2022/06/23 17:42:45.690266756   Using cached SQLAlchemy-1.4.36-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.6 MB)',\n",
-       "  '2022/06/23 17:42:45.770326111 Collecting stack-data==0.2.0',\n",
-       "  '2022/06/23 17:42:45.804365547   Using cached stack_data-0.2.0-py3-none-any.whl (21 kB)',\n",
-       "  '2022/06/23 17:42:45.900811554 Collecting starlette==0.17.1',\n",
-       "  '2022/06/23 17:42:45.941468209   Using cached starlette-0.17.1-py3-none-any.whl (58 kB)',\n",
-       "  '2022/06/23 17:42:46.018280028 Collecting terminado==0.13.3',\n",
-       "  '2022/06/23 17:42:46.056823137   Using cached terminado-0.13.3-py3-none-any.whl (14 kB)',\n",
-       "  '2022/06/23 17:42:46.140584719 Collecting threadpoolctl==3.1.0',\n",
-       "  '2022/06/23 17:42:46.176671731   Using cached threadpoolctl-3.1.0-py3-none-any.whl (14 kB)',\n",
-       "  '2022/06/23 17:42:46.261344955 Collecting tinycss2==1.1.1',\n",
-       "  '2022/06/23 17:42:46.296603983   Using cached tinycss2-1.1.1-py3-none-any.whl (21 kB)',\n",
-       "  '2022/06/23 17:42:46.413149102 Collecting torch==1.11.0',\n",
-       "  '2022/06/23 17:42:51.054811174   Using cached torch-1.11.0-cp39-cp39-manylinux1_x86_64.whl (750.6 MB)',\n",
-       "  '2022/06/23 17:42:55.049381342 Collecting tornado==6.1',\n",
-       "  '2022/06/23 17:42:55.087232190   Using cached tornado-6.1-cp39-cp39-manylinux2010_x86_64.whl (427 kB)',\n",
-       "  '2022/06/23 17:42:55.198546868 Collecting traitlets==5.1.1',\n",
-       "  '2022/06/23 17:42:55.238109736   Using cached traitlets-5.1.1-py3-none-any.whl (102 kB)',\n",
-       "  '2022/06/23 17:42:55.324539992 Collecting typing_extensions==4.2.0',\n",
-       "  '2022/06/23 17:42:55.365981670   Using cached typing_extensions-4.2.0-py3-none-any.whl (24 kB)',\n",
-       "  '2022/06/23 17:42:55.483310061 Collecting urllib3==1.26.9',\n",
-       "  '2022/06/23 17:42:55.520489858   Using cached urllib3-1.26.9-py2.py3-none-any.whl (138 kB)',\n",
-       "  '2022/06/23 17:42:55.621124941 Collecting uvicorn==0.17.6',\n",
-       "  '2022/06/23 17:42:55.657447186   Using cached uvicorn-0.17.6-py3-none-any.whl (53 kB)',\n",
-       "  '2022/06/23 17:42:55.744884811 Collecting vetiver==0.1.4',\n",
-       "  '2022/06/23 17:42:55.786137339   Using cached vetiver-0.1.4-py3-none-any.whl (20 kB)',\n",
-       "  '2022/06/23 17:42:55.869486037 Collecting wcwidth==0.2.5',\n",
-       "  '2022/06/23 17:42:55.903391236   Using cached wcwidth-0.2.5-py2.py3-none-any.whl (30 kB)',\n",
-       "  '2022/06/23 17:42:56.012627397 Collecting webencodings==0.5.1',\n",
-       "  '2022/06/23 17:42:56.048168300   Using cached webencodings-0.5.1-py2.py3-none-any.whl (11 kB)',\n",
-       "  '2022/06/23 17:42:56.152835980 Collecting xgboost==1.6.1',\n",
-       "  '2022/06/23 17:42:57.257676104   Using cached xgboost-1.6.1-py3-none-manylinux2014_x86_64.whl (192.9 MB)',\n",
-       "  '2022/06/23 17:42:58.401460834 Collecting xxhash==3.0.0',\n",
-       "  '2022/06/23 17:42:58.438647474   Using cached xxhash-3.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (211 kB)',\n",
-       "  '2022/06/23 17:42:58.531069831 Collecting zipp==3.8.0',\n",
-       "  '2022/06/23 17:42:58.569257062   Using cached zipp-3.8.0-py3-none-any.whl (5.4 kB)',\n",
-       "  '2022/06/23 17:42:58.755655211 Collecting websockets',\n",
-       "  '2022/06/23 17:42:58.795621982   Using cached websockets-10.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (111 kB)',\n",
-       "  '2022/06/23 17:42:58.864392160 Collecting aiofiles',\n",
-       "  '2022/06/23 17:42:58.901300113   Using cached aiofiles-0.8.0-py3-none-any.whl (13 kB)',\n",
-       "  '2022/06/23 17:42:59.547003395 Requirement already satisfied: setuptools>=18.5 in /opt/rstudio-connect/mnt/python-environments/ghcr.io_rstudio_content-pro__r4.0.5-py3.9.2-bionic/pip/3.9.2/0ayN2gFf0XzZbelHEANT0A/lib/python3.9/site-packages (from ipython==8.2.0->-r python/requirements.txt (line 30)) (62.6.0)',\n",
-       "  '2022/06/23 17:43:02.845474971 Installing collected packages: webencodings, wcwidth, Send2Trash, pytz, pyodbc, pure-eval, ptyprocess, pickleshare, mistune, ipython-genutils, fastjsonschema, executing, certifi, backcall, zipp, xxhash, websockets, urllib3, typing_extensions, traitlets, tornado, tinycss2, threadpoolctl, soupsieve, sniffio, semver, pyzmq, PyYAML, python-dotenv, python-dateutil, pyrsistent, pyparsing, Pygments, pycparser, psycopg2, psutil, prompt-toolkit, prometheus-client, pexpect, parso, pandocfilters, numpy, nest-asyncio, MarkupSafe, jupyterlab-pygments, joblib, idna, humanize, h11, greenlet, fsspec, entrypoints, defusedxml, decorator, debugpy, click, charset-normalizer, bleach, attrs, asttokens, asgiref, aiofiles, uvicorn, torch, terminado, stack-data, SQLAlchemy, scipy, requests, pydantic, pandas, packaging, matplotlib-inline, jupyter-core, jsonschema, Jinja2, jedi, importlib-resources, importlib-metadata, cffi, beautifulsoup4, anyio, xgboost, starlette, scikit-learn, pins, nbformat, jupyter-client, ipython, argon2-cffi-bindings, sklearn, nbclient, ipykernel, fastapi, argon2-cffi, vetiver, nbconvert, notebook',\n",
-       "  '2022/06/23 17:43:10.711530964   Attempting uninstall: certifi',\n",
-       "  '2022/06/23 17:43:10.712687374     Found existing installation: certifi 2022.5.18.1',\n",
-       "  '2022/06/23 17:43:10.719075754     Not uninstalling certifi at /opt/python/3.9.2/lib/python3.9/site-packages, outside environment /opt/rstudio-connect/mnt/app/python/env',\n",
-       "  \"2022/06/23 17:43:10.719897624     Can't uninstall 'certifi'. No files were found to uninstall.\",\n",
-       "  '2022/06/23 17:48:43.188737840 Successfully installed Jinja2-3.1.2 MarkupSafe-2.1.1 PyYAML-6.0 Pygments-2.11.2 SQLAlchemy-1.4.36 Send2Trash-1.8.0 aiofiles-0.8.0 anyio-3.5.0 argon2-cffi-21.3.0 argon2-cffi-bindings-21.2.0 asgiref-3.5.1 asttokens-2.0.5 attrs-21.4.0 backcall-0.2.0 beautifulsoup4-4.11.1 bleach-5.0.0 certifi-2021.10.8 cffi-1.15.0 charset-normalizer-2.0.12 click-8.1.3 debugpy-1.6.0 decorator-5.1.1 defusedxml-0.7.1 entrypoints-0.4 executing-0.8.3 fastapi-0.75.2 fastjsonschema-2.15.3 fsspec-2022.3.0 greenlet-1.1.2 h11-0.13.0 humanize-4.1.0 idna-3.3 importlib-metadata-4.11.3 importlib-resources-5.7.1 ipykernel-6.13.0 ipython-8.2.0 ipython-genutils-0.2.0 jedi-0.18.1 joblib-1.1.0 jsonschema-4.5.1 jupyter-client-7.2.2 jupyter-core-4.10.0 jupyterlab-pygments-0.2.2 matplotlib-inline-0.1.3 mistune-0.8.4 nbclient-0.6.3 nbconvert-6.5.0 nbformat-5.4.0 nest-asyncio-1.5.5 notebook-6.4.11 numpy-1.22.3 packaging-21.3 pandas-1.4.2 pandocfilters-1.5.0 parso-0.8.3 pexpect-4.8.0 pickleshare-0.7.5 pins-0.4.0 prometheus-client-0.14.1 prompt-toolkit-3.0.29 psutil-5.9.0 psycopg2-2.9.3 ptyprocess-0.7.0 pure-eval-0.2.2 pycparser-2.21 pydantic-1.9.0 pyodbc-4.0.32 pyparsing-3.0.8 pyrsistent-0.18.1 python-dateutil-2.8.2 python-dotenv-0.20.0 pytz-2022.1 pyzmq-22.3.0 requests-2.27.1 scikit-learn-1.0.2 scipy-1.8.0 semver-2.13.0 sklearn-0.0 sniffio-1.2.0 soupsieve-2.3.2.post1 stack-data-0.2.0 starlette-0.17.1 terminado-0.13.3 threadpoolctl-3.1.0 tinycss2-1.1.1 torch-1.11.0 tornado-6.1 traitlets-5.1.1 typing_extensions-4.2.0 urllib3-1.26.9 uvicorn-0.17.6 vetiver-0.1.4 wcwidth-0.2.5 webencodings-0.5.1 websockets-10.3 xgboost-1.6.1 xxhash-3.0.0 zipp-3.8.0',\n",
-       "  '2022/06/23 17:48:47.343963741 Packages in the environment: aiofiles==0.8.0, anyio==3.5.0, appdirs==1.4.4, argon2-cffi==21.3.0, argon2-cffi-bindings==21.2.0, asgiref==3.5.1, asttokens==2.0.5, attrs==21.4.0, backcall==0.2.0, beautifulsoup4==4.11.1, bleach==5.0.0, certifi==2021.10.8, cffi==1.15.0, charset-normalizer==2.0.12, click==8.1.3, debugpy==1.6.0, decorator==5.1.1, defusedxml==0.7.1, distlib, entrypoints==0.4, executing==0.8.3, fastapi==0.75.2, fastjsonschema==2.15.3, filelock, fsspec==2022.3.0, greenlet==1.1.2, h11==0.13.0, humanize==4.1.0, idna==3.3, importlib-metadata==4.11.3, importlib-resources==5.7.1, ipykernel==6.13.0, ipython==8.2.0, ipython-genutils==0.2.0, jedi==0.18.1, Jinja2==3.1.2, joblib==1.1.0, jsonschema==4.5.1, jupyter-client==7.2.2, jupyter-core==4.10.0, jupyterlab-pygments==0.2.2, MarkupSafe==2.1.1, matplotlib-inline==0.1.3, mistune==0.8.4, nbclient==0.6.3, nbconvert==6.5.0, nbformat==5.4.0, nest-asyncio==1.5.5, notebook==6.4.11, numpy==1.22.3, packaging==21.3, pandas==1.4.2, pandocfilters==1.5.0, parso==0.8.3, pexpect==4.8.0, pickleshare==0.7.5, pins==0.4.0, prometheus-client==0.14.1, prompt-toolkit==3.0.29, psutil==5.9.0, psycopg2==2.9.3, ptyprocess==0.7.0, pure-eval==0.2.2, pycparser==2.21, pydantic==1.9.0, Pygments==2.11.2, pyodbc==4.0.32, pyparsing==3.0.8, pyrsistent==0.18.1, python-dateutil==2.8.2, python-dotenv==0.20.0, pytz==2022.1, PyYAML==6.0, pyzmq==22.3.0, requests==2.27.1, scikit-learn==1.0.2, scipy==1.8.0, semver==2.13.0, Send2Trash==1.8.0, six, sklearn==0.0, sniffio==1.2.0, soupsieve==2.3.2.post1, SQLAlchemy==1.4.36, stack-data==0.2.0, starlette==0.17.1, terminado==0.13.3, threadpoolctl==3.1.0, tinycss2==1.1.1, torch==1.11.0, tornado==6.1, traitlets==5.1.1, typing_extensions==4.2.0, urllib3==1.26.9, uvicorn==0.17.6, vetiver==0.1.4, virtualenv, wcwidth==0.2.5, webencodings==0.5.1, websockets==10.3, xgboost==1.6.1, xxhash==3.0.0, zipp==3.8.0, ',\n",
-       "  '2022/06/23 17:48:47.347373756 Creating lockfile: python/requirements.txt.lock',\n",
-       "  'Stopped session pings to http://172.19.57.196:32636',\n",
-       "  'Launching FastAPI application...'])"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "deploy_python_fastapi(\n",
-    "    connect_server = connect_server,\n",
-    "    title = \"Random Forest model for bike share 23-06\",\n",
-    "    directory = \".\",\n",
-    "    python = \".bike_predict_vetiver/bin/python\",\n",
-    "    extra_files = None,\n",
-    "    entry_point = \"model_new:api\",\n",
-    "    excludes = None,\n",
-    ")"
-   ]
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "bike_predict_vetiver",
+   "display_name": "Python 3.9.11 64-bit ('pydemo')",
    "language": "python",
-   "name": "bike_predict_vetiver"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1039,7 +496,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.9.11"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "974018313955b4988b16ea215671657307c8736770f13695d4ded4c5899ccb5a"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
hi gang! in this PR, I am revamping your `vetiver_deployment.ipynb`. The biggest change here is that we are using the new `vetiver.deploy_rsconnect` function! This should streamline the process a bunch. A few notes:

- I am using my [`isabel.zimmerman/iz-bike`](https://colorado.rstudio.com/rsc/connect/#/apps/601ca01f-11a5-4a45-9ad7-8e97e346c08c/access) pin. It is the same model as the [`gagan/bikeshare-rf`](https://colorado.rstudio.com/rsc/connect/#/apps/f45a2266-ba3c-4524-9570-7661716c8851/access), but it has a ptype saved. I remember you had said the API not working, and I think the problem was the API and specified `check_ptype = True`, but the model did not have a `ptype` saved. I opened an issue about this in vetiver to give better explanation when this happens 👀 I added a `ptype` to the model rather than not enforce it from the API, since the visual documentation will only show information about the input variables if there is a ptype supplied.
- I showed how to load a model from a pin (`vt.VetiverModel.from_pin()`), but you can deploy right from the pinned model, no need to load it locally!

I'm not sure where else you are planning on using vetiver, but feel free to point me in the direction of those notebooks if any other help is needed!

All of this was done using the github version of vetiver, but we will have another release (0.1.6) to PyPI pre-conf. Let me know if you have any other questions/comments/concerns!